### PR TITLE
Bugfix: Catch undefined options

### DIFF
--- a/bin/pngpetite
+++ b/bin/pngpetite
@@ -22,7 +22,7 @@ set -o pipefail
 # Globals
 # -----------------------------------------------------------------------------
 
-declare -r VERSION=0.2.2
+declare -r VERSION=0.2.3
 declare -r SCRIPT=${0##*/}
 declare -r SUFFIX="-${SCRIPT}.png"
 declare -r PNGQUANT_OPTS="--quality=80-98 --skip-if-larger --force"
@@ -95,7 +95,7 @@ USAGE
 # -----------------------------------------------------------------------------
 
 function parse_options() {
-  [[ $# -eq 0 ]] && usage 1
+  [[ $# -eq 0 ]] && usage 11
   while [[ ${#} -gt 0 ]]; do
     case ${1} in
     -r|--replace)  REPLACE=true;;
@@ -104,6 +104,7 @@ function parse_options() {
     -q|--quiet)    QUIET=true; PRINT_STATS=false;;
     -S|--no-stats) PRINT_STATS=false;;
     -V|--version)  print_version;;
+    -*)            usage 12;;
     *)             FILES=( "${FILES[@]-}" "${1}" )
     esac
     shift
@@ -209,7 +210,7 @@ function replace_file() {
 function check_image_type() {
   local image="${1}"; shift;
   local status=true
-  [[ $(file "${image}") =~ 'PNG image data' ]] && return 0
+  [[ $(file -- "${image}") =~ 'PNG image data' ]] && return 0
   echo "ALERT: Unable to Process File"
   echo "'${image}' does not appear to be a png file"
   return 1

--- a/tests/functions.bash
+++ b/tests/functions.bash
@@ -16,7 +16,9 @@ function run_pngpetite() {
   local png=${1}; shift;
   local dir=${1:-${HOME}/tmp/pngpetite/${RANDOM}}
   local bindir=${BATS_TEST_DIRNAME}/../bin
-
-  run ${bindir}/pngpetite -d "${dir}" "${png}"
-  [[ -f ${dir}/${png##*/} ]] || echo "${output}"
+  
+  run ${bindir}/pngpetite --quiet --dest "${dir}" "${png}"
+  echo ${output}
+  (( ${status} != 0 )) && return ${status}
+  [[ -f ${dir}/${png##*/} ]] && return 0 || return 1
 }

--- a/tests/regressions.bats
+++ b/tests/regressions.bats
@@ -1,11 +1,21 @@
 load functions
 
-@test "Check non png file" {
-  run_pngpetite ${BATS_TEST_DIRNAME}/functions.bash
-  [[ ${output} =~ 'does not appear to be a png file' ]]
+@test "Regression: Check non PNG file" {
+  run_pngpetite ${BATS_TEST_DIRNAME}/functions.bash || :
+  [[ ${output,,} =~ 'unable to process file' ]]
 }
 
-@test "Check non existing file" {
-  run_pngpetite ${BATS_TEST_DIRNAME}/non-existing-file.png
-  [[ ${output} =~ 'does not appear to be a png file' ]]
+@test "Regression: Check non existing file" {
+  run_pngpetite ${BATS_TEST_DIRNAME}/non-existing-file.png || :
+  [[ ${output,,} =~ 'unable to process file' ]]
+}
+
+@test "Regression: Check no options or file provided" {
+  run ${BATS_TEST_DIRNAME}/../bin/pngpetite || :
+  (( ${status} == 11 ))
+}
+
+@test "Regression: Check non-existing option" {
+  run ${BATS_TEST_DIRNAME}/../bin/pngpetite --foobar || :
+  (( ${status} == 12 ))
 }


### PR DESCRIPTION
Summary:
  * Change the exit code for no file or
    option given to 11.
  * Catch undefined options and return an
    Error code of 12.