### PR TITLE
Bugfix: Time measurement in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:edge
 LABEL MAINTAINERS="Urs Roesch <github@bun.ch>"
 
 ARG pngpetite_version
-ENV VERSION=${pngpetite_version:-v0.4.0}
+ENV VERSION=${pngpetite_version:-v0.4.1}
 
 # Installing package required for the runtime of
 # any of the asciidoctor-* functionnalities
@@ -14,6 +14,7 @@ RUN \
     coreutils \
     file \
     pngquant \
+    procps \
     zopfli
 
 COPY bin/pngpetite /bin/

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DOCKERHUB_USERNAME ?= uroesch
 CURRENT_GIT_REF ?= $(shell git rev-parse --abbrev-ref HEAD) # Default to current branch
 DOCKER_IMAGE_TAG ?= $(shell echo $(CURRENT_GIT_REF) | sed 's|.*/.*[^-]-|v|g')
 DOCKER_IMAGE_NAME_TO_TEST ?= $(DOCKERHUB_USERNAME)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)
-PNGPETITE_VERSION ?= 0.4.0
+PNGPETITE_VERSION ?= 0.4.1
 
 export \
   DOCKER_IMAGE_NAME_TO_TEST \

--- a/bin/pngpetite
+++ b/bin/pngpetite
@@ -17,13 +17,12 @@
 set -o nounset
 set -o errexit
 set -o pipefail
-set -o monitor   # For docker
 
 # -----------------------------------------------------------------------------
 # Globals
 # -----------------------------------------------------------------------------
 
-declare -r VERSION=0.4.0
+declare -r VERSION=0.4.1
 declare -r SCRIPT=${0##*/}
 declare -r SUFFIX="-${SCRIPT}.png"
 declare -r S1_SUFFIX="-${RANDOM}"
@@ -181,20 +180,8 @@ function inside_docker() {
 
 # -----------------------------------------------------------------------------
 
-function wait_for_file() {
-  local file="${1}"
-  inside_docker || return 0
-  # On docker the file write is a bit lagging hence the loop
-  while [[ ! -f ${file} ]]; do
-    sleep 0.1
-  done
-}
-
-# -----------------------------------------------------------------------------
-
 function get_size() {
   local file="${1}"
-  wait_for_file "${file}"
   stat ${STAT_OPTS} "${file}" 2>/dev/null || echo "N/A"
 }
 
@@ -284,6 +271,16 @@ function create_scaffold() {
 
 # -----------------------------------------------------------------------------
 
+function change_file_owner() {
+  local image="${1}"; shift
+  local working_image="${1}"; shift
+  inside_docker || return 0
+  [[ -n ${DEST_DIR} ]] && chown -R --reference="${image}" ${DEST_DIR%%/*}
+  chown -R --reference="${image}" "${working_image}"
+}
+
+# -----------------------------------------------------------------------------
+
 function format() {
   local type=${1}; shift;
   local item=""
@@ -362,8 +359,7 @@ function process_images() {
 
     # put final image into place and change permission if inside docker
     mv "${working_image}${S2_SUFFIX}" "${working_image}"
-    inside_docker && \
-      chown -R --reference="${image}" ${DEST_DIR%%/*} "${working_image}"
+    change_file_owner "${image}" "${working_image}"
 
     ## butteraugli section
     score=$(run_butteraugli "${image}" "${working_image}")

--- a/tests/docker.bats
+++ b/tests/docker.bats
@@ -7,10 +7,21 @@ load functions
   docker build -t uroesch/pngpetite .
 }
 
-@test "Docker Compress *.png" {
+@test "Docker: Compress *.png" {
   testdir=${BATS_TEST_DIRNAME}/test-${RANDOM}
   mkdir -p ${testdir}
   cp ${BATS_TEST_DIRNAME}/../samples/original/*png ${testdir}
   ${BATS_TEST_DIRNAME}/../bin/docker-pngpetite ${testdir}/*png
+  rm ${testdir}/*.png
+}
+
+@test "Docker: Check file permission after compression" {
+  testdir=${BATS_TEST_DIRNAME}/test-${RANDOM}
+  mkdir -p ${testdir}
+  cp ${BATS_TEST_DIRNAME}/../samples/original/beach.png ${testdir}
+  perm_original=$(stat --format "%u:%g" ${testdir}/beach.png)
+  ${BATS_TEST_DIRNAME}/../bin/docker-pngpetite ${testdir}/beach.png
+  perm_shrunk=$(stat --format "%u:%g" ${testdir}/beach-pngpetite.png)
+  [[ ${perm_shrunk} == ${perm_original} ]]
   rm ${testdir}/*.png
 }

--- a/tests/functions.bash
+++ b/tests/functions.bash
@@ -16,7 +16,7 @@ function run_pngpetite() {
   local png=${1}; shift;
   local dir=${1:-${HOME}/tmp/pngpetite/${RANDOM}}
   local bindir=${BATS_TEST_DIRNAME}/../bin
-  
+
   run ${bindir}/pngpetite --quiet --dest "${dir}" "${png}"
   echo ${output}
   (( ${status} != 0 )) && return ${status}


### PR DESCRIPTION
Summary:
  * Fix bug in docker image where compression
    time was not calculated correctly.
    Problem was the version of `ps` on the
    alpine image.
  * Remove some functions which are no
    longer required.