### PR TITLE
Release version 0.4.3

### DIFF
--- a/.github/workflows/bash-compatibility.yml
+++ b/.github/workflows/bash-compatibility.yml
@@ -1,0 +1,60 @@
+# -----------------------------------------------------------------------------
+# Verify bash compatibility
+# Author: Urs Roesch https://github.com/uroesch
+# Version: 0.2.0
+# -----------------------------------------------------------------------------
+name: bash-compatibility
+
+on:
+  push:
+    branches:
+    - workflow/*
+  pull_request:
+    branches:
+    - master
+    - main
+
+jobs:
+  bash-compatibility:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    container:
+      image: bash:${{ matrix.bash }}
+    strategy:
+      fail-fast: false
+      matrix:
+        bash:
+          - '4.0'
+          - '4.1'
+          - '4.2'
+          - '4.3'
+          - '4.4'
+          - '5.0'
+          - '5.1'
+          - '5.2'
+
+    steps:
+    - name: Install apk dependencies
+      shell: bash
+      run: |
+        apk add \
+          bats \
+          bc \
+          coreutils \
+          file \
+          git \
+          git-lfs \
+          pngquant \
+          procps \
+          zopfli
+
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+
+    - name: Check bash compatibilty
+      shell: bash
+      run: |
+        shopt -s extglob 
+        bats tests/!(docker).bats 

--- a/.github/workflows/bats-unit-test.yml
+++ b/.github/workflows/bats-unit-test.yml
@@ -31,10 +31,10 @@ jobs:
       run: |
         sudo apt -y install \
           bats \
-          pngquant \
-          zopfli \
           bc \
-          file
+          file \
+          pngquant \
+          zopfli
 
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:edge
 LABEL MAINTAINERS="Urs Roesch <github@bun.ch>"
 
 ARG pngpetite_version
-ENV VERSION=${pngpetite_version:-v0.4.2}
+ENV VERSION=${pngpetite_version:-v0.4.3}
 
 # Installing package required for the runtime of
 # any of the asciidoctor-* functionnalities

--- a/bin/pngpetite
+++ b/bin/pngpetite
@@ -22,7 +22,7 @@ set -o pipefail
 # Globals
 # -----------------------------------------------------------------------------
 
-declare -r VERSION=0.4.2
+declare -r VERSION=0.4.3
 declare -r SCRIPT=${0##*/}
 declare -r SUFFIX="-${SCRIPT}.png"
 declare -r S1_SUFFIX="-${RANDOM}"
@@ -30,12 +30,12 @@ declare -r S2_SUFFIX="-${RANDOM}"
 declare -r PNGQUANT_OPTS="--quality=80-98 --skip-if-larger --force"
 declare -r ZOPFLI_OPTS='-m -y --lossy_8bit --lossy_transparent'
 declare -r STAT_OPTS='--printf %s'
-declare -g WITH_BUTTERAUGLI=false
-declare -g HEADER_PRINTED=false
-declare -g REPLACE=false
-declare -g QUIET=false
-declare -g PRINT_STATS=true
-declare -g DEST_DIR=""
+declare -- WITH_BUTTERAUGLI=false
+declare -- HEADER_PRINTED=false
+declare -- REPLACE=false
+declare -- QUIET=false
+declare -- PRINT_STATS=true
+declare -- DEST_DIR=""
 declare -a FILES=()
 declare -a FIELDS_HEADER=(
   "Original (KB)"
@@ -71,7 +71,8 @@ function check_dependencies() {
 
 function check_butteraugli() {
   if ! which butteraugli >/dev/null 2>&1; then
-    unset FIELDS_HEADER[-2]
+    # this wordy monster is for bash 4.0, 4.1 and 4.2 compatibility
+    unset FIELDS_HEADER[$(( ${#FIELDS_HEADER[@]} - 2 ))]
   else
     WITH_BUTTERAUGLI=true
   fi


### PR DESCRIPTION
- Add bash compatibility tests.
- Make compatible with bash 4.0, 4.1 and bash 4.2.
- Compatibilty changes for pngpetite only.